### PR TITLE
Add information regarding --harmony-generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Binaries won't work with `node-protobuf` -- some libraries are not properly link
 npm install rethinkdbdash
 ```
 
-  To use the `yield` functionality of rethinkdbdash, you must be running __node 0.11.9__ or higher for generator support, and must run node(1)
+  __Please Note:__ To use the `yield` functionality of rethinkdbdash, you must be running __node 0.11.9__ or higher for generator support, and must run node(1)
   with the `--harmony` flag. If you don't like typing this, add an alias to your shell profile:
 
 ```


### PR DESCRIPTION
This pull request adds a warning to the Install section of the README file, regarding the use of ES6 `yield`:

**Please Note:** To use the `yield` functionality of rethinkdbdash, you must be running **node 0.11.9** or higher for generator support, and must run node(1) with the `--harmony` flag. If you don't like typing this, add an alias to your shell profile:

```
 alias node='node --harmony'
```
