### PR TITLE
Add Cursor.createReadStream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ var result = yield cursor.toArray();
 console.log(JSON.stringify(result)) // print [1, 2, 3]
 ```
 
+#### `.createReadStream()` ####
+
+Calling `.createReadStream()` on a cursor returns a [Readable Stream](http://nodejs.org/api/stream.html#stream_class_stream_readable), which emits `data` events for each item in the cursor.
+
+Example:
+```javascript
+var through = require('through2');
+
+var cursor = yield r.expr(["a", "b", "c"]).run();
+var stream = cursor.createReadStream();
+
+stream.pipe(through(function(chunk, enc, callback) {
+    for (var i = 0; i < chunk.length; i++) {
+        if (chunk[i] == 97) { //if chunk is 'a'
+            chunk[i] = 122; // swap 'a' for 'z'
+        }
+    }
+    this.push(chunk);
+    callback();
+})).pipe(process.stdout);
+```
 
 #### Errors ####
 - Better backtraces

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,5 +1,6 @@
 var Promise = require("bluebird");
 var pb = require(__dirname+"/protobuf.js");
+var cs = require(__dirname+"/stream.js");
 
 function Cursor(connection, token, options) {
     this.connection = connection;
@@ -172,6 +173,11 @@ Cursor.prototype.close = function() {
         }
     });
     return p;
+}
+
+Cursor.prototype.createReadStream = function() {
+  var stream = cs(this);
+  return stream;
 }
 
 module.exports = Cursor;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,27 @@
+var Readable = require('stream').Readable;
+var util = require('util');
+
+function CursorStream(cursor) {
+  if (!(this instanceof CursorStream)) {
+    return new CursorStream(cursor);
+  }
+  Readable.call(this, {
+    objectMode: true
+  });
+  this._cursor = cursor;
+}
+util.inherits(CursorStream, Readable);
+
+CursorStream.prototype._read = function read() {
+  var self = this;
+  while(this._cursor.hasNext()) {
+    this._cursor.next().then(function (next) {
+        self.push(next);
+    }).error (function(err) {
+        self.emit('error', err);
+        return;
+    });
+  }
+};
+
+module.exports = CursorStream;

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -284,3 +284,23 @@ It("`next` should error when hitting an error -- not on the first batch", functi
         }
     }
 })
+
+It("`createReadStream` should emit a data event for each item in the cursor", function* (done) {
+  var i = 0;
+
+  var cursor = yield r.expr(["a", "b", "c"]).run();
+  var stream = cursor.createReadStream();
+
+  stream.on('data', function(data) {
+    i++;
+    if(i==3) {
+      try {
+        assert(i == 3);
+      } catch(e) {
+        done(e);
+      } finally {
+        done();
+      }
+    }
+  });
+})


### PR DESCRIPTION
This pull request adds `.createReadStream()` to Cursor:

```javascript
co(function *(){
    var cursor = yield r.expr([1, 2, 3]).run();
    var stream = cursor.createReadStream();

    stream.pipe(process.stdout);
})();
```

A unit test is included