### PR TITLE
Remove conflicting error method

### DIFF
--- a/lib/term.js
+++ b/lib/term.js
@@ -2666,9 +2666,6 @@ Term.prototype.rebalance = function() {
 Term.prototype.then = function(resolve, reject) {
     return this.run().then(resolve, reject);
 }
-Term.prototype.error = function(reject) {
-    return this.run().error(reject);
-}
 Term.prototype.catch = function(reject) {
     return this.run().catch(reject);
 }


### PR DESCRIPTION
Conflicts with r.error, and doesn't provide anything that can't be done with catch().