### PR TITLE
Allow 0 argument in literal

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,11 +175,12 @@ r.prototype.dbList = function() {
   return new Term(this).dbList();
 };
 r.prototype.literal = function(obj) {
-  if (Term.prototype._fastArity(arguments.length, 1) === false) {
+  if (Term.prototype._fastArityRange(arguments.length, 0, 1) === false) {
     var _len = arguments.length;var _args = new Array(_len); for(var _i = 0; _i < _len; _i++) {_args[_i] = arguments[_i];}
-    Term.prototype._arity(_args, 1, 'r.literal', this);
+    Term.prototype._arityRange(_args, 0, 1, 'r.literal', this);
   }
-  return new Term(this).literal(obj);
+  var term = new Term(this);
+  return obj === undefined ? term.literal() : term.literal(obj);
 };
 r.prototype.desc = function(field) {
   if (Term.prototype._fastArity(arguments.length, 1) === false) {

--- a/lib/term.js
+++ b/lib/term.js
@@ -1283,9 +1283,9 @@ Term.prototype.merge = function(arg) {
 }
 Term.prototype.literal = function(obj) {
     this._noPrefix(this, 'literal');
-    if (this._fastArity(arguments.length, 1) === false) {
+    if (this._fastArityRange(arguments.length, 0, 1) === false) {
         var _len = arguments.length;var _args = new Array(_len); for(var _i = 0; _i < _len; _i++) {_args[_i] = arguments[_i];}
-        this._arity(_args, 1, 'literal', this);
+        this._arityRange(_args, 0, 1, 'literal', this);
     }
 
     var term = new Term(this._r, this._error);

--- a/lib/term.js
+++ b/lib/term.js
@@ -1290,7 +1290,9 @@ Term.prototype.literal = function(obj) {
 
     var term = new Term(this._r, this._error);
     term._query.push(termTypes.LITERAL)
-    term._query.push([new Term(this._r).expr(obj)._query])
+    if (obj !== undefined) {
+        term._query.push([new Term(this._r).expr(obj)._query])
+    }
     return term;
 }
 Term.prototype.append = function(value) {


### PR DESCRIPTION
As stated in the doc:

> Using literal with no arguments in a merge or update operation will remove the corresponding field.

http://rethinkdb.com/api/javascript/literal/

Note: tests should fail...