### PR TITLE
Turn on TCP keepalive

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,6 +43,7 @@ function Connection(r, options, resolve, reject) {
     port: self.port,
     family: family
   });
+  self.connection.setKeepAlive(true);
 
   self.timeoutOpen = setTimeout(function() {
     self.connection.end(); // Send a FIN packet


### PR DESCRIPTION
See the discussion in https://github.com/rethinkdb/rethinkdb/issues/4572 .

This allows rethinkdbdash to notice when an inactive connection is dead (though with the default settings on Linux, this still takes 11 minutes).