### PR TITLE
Performance improvement to convertPseudoType helper

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -59,50 +59,53 @@ function loopKeys(obj, fn) {
 }
 module.exports.loopKeys = loopKeys;
 
-function convertPseudoType(obj, options) {
+function convertPseudotype(obj, options) {
+  var reqlType = obj['$reql_type$'];
+  if (reqlType === 'TIME' && options['timeFormat'] !== 'raw') {
+    return new Date(obj['epoch_time'] * 1000);
+  }
+  else if (reqlType === 'GROUPED_DATA' && options['groupFormat'] !== 'raw') {
+    var result = [];
+    for (var i = 0, len = obj['data'].length, ref; i < len; i++) {
+      ref = obj.data[i];
+      result.push({
+        group: ref[0],
+        reduction: ref[1]
+      });
+    }
+    return result;
+  }
+  else if (reqlType === 'BINARY' && options['binaryFormat'] !== 'raw') {
+    return new Buffer(obj['data'], 'base64');
+  }
+  return obj;
+}
+function recursivelyConvertPseudotype(obj, options) {
+  var i, value, len, key;
   if (Array.isArray(obj)) {
-    for(var i=0; i<obj.length; i++) {
-      obj[i] = convertPseudoType(obj[i], options);
+    for (i = 0, len = obj.length; i < len; i++) {
+      value = obj[i];
+      obj[i] = recursivelyConvertPseudotype(value, options);
     }
   }
-  else if (isPlainObject(obj)) {
-    if ((options.timeFormat != 'raw') && (obj.$reql_type$ === 'TIME')) {
-      obj = new Date(obj.epoch_time*1000);
+  else if (obj && typeof obj === 'object') {
+    for (key in obj) {
+      value = obj[key];
+      obj[key] = recursivelyConvertPseudotype(value, options);
     }
-    else if ((options.binaryFormat != 'raw') && (obj.$reql_type$ === 'BINARY')) {
-      obj = new Buffer(obj.data, 'base64');
-    }
-    else if ((options.groupFormat != 'raw') && (obj.$reql_type$ === 'GROUPED_DATA')) {
-      var result = [];
-      for(var i=0; i<obj.data.length; i++) {
-        result.push({
-          group: convertPseudoType(obj.data[i][0], options),
-          reduction: convertPseudoType(obj.data[i][1], options),
-        })
-      }
-      obj = result;
-    }
-    else{
-      for(var key in obj) {
-        if (obj.hasOwnProperty(key)) {
-          obj[key] = convertPseudoType(obj[key], options);
-        }
-      }
-    }
+    obj = convertPseudotype(obj, options);
   }
   return obj;
 }
 function makeAtom(response, options) {
   options = options || {};
-  return convertPseudoType(response.r[0], options);
+  return recursivelyConvertPseudotype(response.r[0], options);
 }
 module.exports.makeAtom = makeAtom;
 
 function makeSequence(response, options) {
-  var result = [];
   options = options || {};
-
-  return convertPseudoType(response.r, options);
+  return recursivelyConvertPseudotype(response.r, options);
 }
 
 module.exports.makeSequence = makeSequence;


### PR DESCRIPTION
Hi, I've been doing some profiling to a Node project I've been working on, where I use *rethinkdbdash*, and I noticed that, when fetching big results from RethinkDB, the *convertPseudoType* helper could be consuming a lot of time and, being synchronous, blocking the Node event loop during this time. I did a few optimizations from and I got the following results:

* Object to convert: [fathers.txt](https://github.com/neumino/rethinkdbdash/files/84198/fathers.txt)
* Node script used:

```javascript
// Copy pasted data into variable fathers.
var fathers = ....;


// Test 1.
var startTime = Date.now();
for (var i = 0; i < 10; i++) {
    convertPseudoType(fathers, {}); // Current implementation.
}
console.log(Date.now() - startTime);
// Prints 360.

// Test 2.
startTime = Date.now();
for (var i = 0; i < 10; i++) {
    recursivelyConvertPseudotype(fathers, {}); // Optimized version.
}
console.log(Date.now() - startTime);
// Prints 31.
```

So the helper can now be about 10x faster and, as far as I know, produce the same results. 