### PR TITLE
Make `eachAsync` consistent with behavior of official driver

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -258,43 +258,25 @@ Cursor.prototype._each = function(callback, onFinish) {
   });
   return null;
 }
-Cursor.prototype._eachAsync = function(callback, onFinish) {
+Cursor.prototype._eachAsync = function(callback) {
   if (this._closed === true) {
     throw new Err.ReqlDriverError('You cannot retrieve data from a cursor that is closed').setOperational();
   }
   var self = this;
 
-  var reject = function(err) {
-    if (err.message === 'No more rows in the '+self._type.toLowerCase()+'.') {
-      if (typeof onFinish === 'function') {
-        onFinish();
+  var nextCb = function() {
+    return self._next().then(callback).then(nextCb).error(function(error) {
+      if ((error.message === 'No more rows in the '+self._type.toLowerCase()+'.') ||
+          (error.message === 'You cannot retrieve data from a cursor that is closed.') ||
+          (error.message.match(/You cannot call `next` on a closed/) !== null)) {
+        return;
       }
-    }
-    else {
-      throw Err.setOperational(err);
-    }
-  }
-  var resolve = function(data) {
-    return callback(data).then(function() {
-      if (self._closed === false) {
-        return self._next().then(resolve).error(function(error) {
-          if ((error.message !== 'You cannot retrieve data from a cursor that is closed.') &&
-              (error.message.match(/You cannot call `next` on a closed/) === null)) {
-            reject(error);
-          }
-        });
-      }
-      return null;
+
+      throw Err.setOperational(error);
     });
   }
 
-  return self._next().then(resolve).error(function(error) {
-    // We can silence error when the cursor is closed as this 
-    if ((error.message !== 'You cannot retrieve data from a cursor that is closed.') &&
-        (error.message.match(/You cannot call `next` on a closed/) === null)) {
-      reject(error);
-    }
-  });
+  return nextCb();
 }
 
 Cursor.prototype._makeEmitter = function() {


### PR DESCRIPTION
Fixes #225.

@neumino I also got rid of the (optional) `onFinish` callback to this method since it's not supported in the official driver and the purpose of `eachAsync` was to support the promise-style (i.e. `.eachAsync(...).then(/* finish callback */)`. This cleaned up the code a bit too.