### PR TITLE
Allow extra parameter to toJSON

### DIFF
--- a/lib/term.js
+++ b/lib/term.js
@@ -2728,9 +2728,9 @@ Term.prototype.range = function(start, end) {
   return term;
 }
 Term.prototype.toJsonString = function() {
-  if (this._fastArity(arguments.length, 0) === false) {
+  if (this._fastArityRange(arguments.length, 0, 2) === false) {
     var _len = arguments.length;var _args = new Array(_len); for(var _i = 0; _i < _len; _i++) {_args[_i] = arguments[_i];}
-    this._arity(_args, 0, 'toJSON', this);
+    this._arityRange(_args, 0, 2, 'toJSON', this);
   }
   var term = new Term(this._r);
   term._query.push(termTypes.TO_JSON_STRING);


### PR DESCRIPTION
When calling toJsonString from code that's been wrapped with an ES6 polyfill, the
toJSON call can include one to two optional parameters. Even though we're ignoring
the extra parameters, this will prevent the code from throwing an error when
it sees them.

I know this isn't ideal, but the fix, as applied, at least lets the code run, though it obviously ignores the filtering/formatting parameter(s). It seems that the extra parameter is added by the babel-polyfill: It's a "replacer" that, if no other replacer is given, filters out ES6 symbols from the output. 

Below you can find the call stack that I was getting. I was handing an object to socket.io, which then called Object.stringify from babel-polyfill, which then ended up at Term.toJsonString with an extra parameter.

Without this the code throws an error and crashes; I'm sending it as a pull request in case you want to apply the (very simple) patch, but if you decide that you'd rather *really* handle those extra parameters correctly, then please do. For now I've pointed my server at the fork so it will work.

23 Feb 21:55:09 - Stack: ReqlDriverError: `toJSON` takes 0 argument, 1 provided after:
r.now()
    at Term._arity (/var/node/GoSkipServer/node_modules/rethinkdbdash/lib/term.js:2974:11)
    at Term.toJsonString (/var/node/GoSkipServer/node_modules/rethinkdbdash/lib/term.js:2733:10)
    at Object.stringify (native)
    at Object.stringify (/var/node/GoSkipServer/node_modules/babel-polyfill/node_modules/core-js/modules/es6.symbol.js:128:21)
    at encodeAsString (/var/node/GoSkipServer/node_modules/socket.io/node_modules/socket.io-parser/index.js:179:17)
    at Encoder.encode (/var/node/GoSkipServer/node_modules/socket.io/node_modules/socket.io-parser/index.js:134:20)
    at Client.packet (/var/node/GoSkipServer/node_modules/socket.io/lib/client.js:155:20)
    at Socket.packet (/var/node/GoSkipServer/node_modules/socket.io/lib/socket.js:205:15)
    at Socket.emit (/var/node/GoSkipServer/node_modules/socket.io/lib/socket.js:155:12)
    at /source/bindhandler.js:7:37
    at _fulfilled (/var/node/GoSkipServer/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/var/node/GoSkipServer/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/var/node/GoSkipServer/node_modules/q/q.js:796:13)
    at /var/node/GoSkipServer/node_modules/q/q.js:604:44
    at runSingle (/var/node/GoSkipServer/node_modules/q/q.js:137:13)
    at flush (/var/node/GoSkipServer/node_modules/q/q.js:125:13)
    at doNTCallback0 (node.js:419:9)
    at process._tickCallback (node.js:348:13)
