### PR TITLE
Emit errors from pool, through pool master, so they can be caught

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -55,7 +55,7 @@ function Pool(r, options) {
     if (self._draining === false) {
       for(var i=0; i<self.options.buffer; i++) {
         if (self.getLength() < self.options.max) {
-          self.createConnection();
+          self.createConnection().catch(function(error){self.emit("error", error)});
         }
       }
     }

--- a/lib/pool_master.js
+++ b/lib/pool_master.js
@@ -47,6 +47,7 @@ function PoolMaster(r, options) {
       for(var i=0; i<options.servers.length; i++) {
         var settings = self.createPoolSettings(options, options.servers[i], self._log);
         pool = new Pool(self._r, settings);
+        pool.on("error", function(error){self.emit("error", error)})
         self._pools[UNKNOWN_POOLS].push(pool);
         // A pool is considered healthy by default such that people can do
         // var = require(...)(); query.run();
@@ -65,6 +66,7 @@ function PoolMaster(r, options) {
     }]
     var settings = self.createPoolSettings(options, {}, self._log);
     pool = new Pool(self._r, settings);
+    pool.on("error", function(error){self.emit("error", error)})
     self._pools[UNKNOWN_POOLS].push(pool);
     self._healthyPools.push(pool);
     self.emitStatus()
@@ -252,6 +254,7 @@ PoolMaster.prototype.createPool = function(server) {
     host: address.host
   }, self._log);
   var pool = new Pool(self._r, settings);
+  pool.on("error", function(error){self.emit("error", error)})
   self._pools[server.id] = pool
   self.initPool(pool);
   self._healthyPools.push(pool);


### PR DESCRIPTION
I made this change to allow me to handle a Wrong Password error thrown by rethink DB.
This is my use case: 

```javascript
const r = _r( {
  host: "192.168.1.89",
  user: "admin",
  password: process.env.RETHINK_PASSWORD,
  db: "deployments",
  silent: true,
} )

r.getPoolMaster()
  .on( "error", ( error ) => (
    error.message.indexOf( "Wrong password" ) > -1 ? process.exit(1) : console.error( error.message )
  ) )
```