### PR TITLE
Fix incompatibility with node 0.10.43 (and probably others)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 var events = require('events');
 var util = require('util');
 var crypto = require('crypto');
+var pbkdf2 = require('pbkdf2-sha256');
 
 var helper = require(__dirname+'/helper.js');
 var Err = require(__dirname+'/error.js');
@@ -83,8 +84,37 @@ function Connection(r, options, resolve, reject) {
     }
 
     var tlsOptions = options.ssl || false;
+    var connectCallback = function(error) {
+      if (error) {
+        reject(new Err.ReqlDriverError('Failed to connect to '+self.host+':'+self.port+'\nFull error:\n'+JSON.stringify(error)).setOperational());
+      } else {
+        self.connection.removeAllListeners('error');
+        self.connection.on('error', function(error) {
+          self.emit('error', error);
+        });
+
+        var versionBuffer = new Buffer(4)
+        versionBuffer.writeUInt32LE(protodef.VersionDummy.Version.V1_0, 0)
+
+        self.randomString = new Buffer(crypto.randomBytes(18)).toString('base64')
+        var authBuffer = new Buffer(JSON.stringify({
+          protocol_version: PROTOCOL_VERSION,
+          authentication_method: AUTHENTIFICATION_METHOD,
+          authentication: "n,,n=" + self.user + ",r=" + self.randomString
+        }));
+
+        helper.tryCatch(function() {
+          self.connection.write(Buffer.concat([versionBuffer, authBuffer, NULL_BUFFER]));
+        }, function(err) {
+          // The TCP connection is open, but the ReQL connection wasn't established.
+          // We can just abort the whole thing
+          self.open = false;
+          reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.host+':'+self.port));
+        });
+      }
+    };
     if (tlsOptions === false) {
-      self.connection = net.connect(connectionArgs);
+      self.connection = net.connect(connectionArgs, connectCallback);
     } else {
       if (helper.isPlainObject(tlsOptions)) {
         // Copy the TLS options in connectionArgs
@@ -92,7 +122,7 @@ function Connection(r, options, resolve, reject) {
           connectionArgs[key] = tlsOptions[key];
         });
       }
-      self.connection = tls.connect(connectionArgs);
+      self.connection = tls.connect(connectionArgs, connectCallback);
     }
   }
 
@@ -120,34 +150,6 @@ function Connection(r, options, resolve, reject) {
     self._flush();
   });
   self.connection.setNoDelay();
-  self.connection.once('error', function(error) {
-    reject(new Err.ReqlDriverError('Failed to connect to '+self.host+':'+self.port+'\nFull error:\n'+JSON.stringify(error)).setOperational());
-  });
-  self.connection.on('connect', function() {
-    self.connection.removeAllListeners('error');
-    self.connection.on('error', function(error) {
-      self.emit('error', error);
-    });
-
-    var versionBuffer = new Buffer(4)
-    versionBuffer.writeUInt32LE(protodef.VersionDummy.Version.V1_0, 0)
-
-    self.randomString = new Buffer(crypto.randomBytes(18)).toString('base64')
-    var authBuffer = new Buffer(JSON.stringify({
-      protocol_version: PROTOCOL_VERSION,
-      authentication_method: AUTHENTIFICATION_METHOD,
-      authentication: "n,,n=" + self.user + ",r=" + self.randomString
-    }));
-
-    helper.tryCatch(function() {
-      self.connection.write(Buffer.concat([versionBuffer, authBuffer, NULL_BUFFER]));
-    }, function(err) {
-      // The TCP connection is open, but the ReQL connection wasn't established.
-      // We can just abort the whole thing
-      self.open = false;
-      reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.host+':'+self.port));
-    });
-  });
   self.connection.once('end', function() {
     self.open = false;
   });
@@ -246,15 +248,14 @@ Connection.prototype._computeSaltedPassword = function(messageServer, reject) {
   if (CACHE_PBKDF2.hasOwnProperty(cacheKey)) {
     self._sendProof(messageServer.authentication, randomNonce, CACHE_PBKDF2[cacheKey]);
   } else {
-    crypto.pbkdf2(self.password, salt, iterations, KEY_LENGTH, "sha256", function(error, saltedPassword) {
-      if (error != null) {
-        self._abort();
-        reject(new Err.ReqlDriverError('Could not derive the key. Error:' + error.toString()));
-      }
+    try {
+      var saltedPassword = pbkdf2(self.password, salt, iterations, KEY_LENGTH);
       CACHE_PBKDF2[cacheKey] = saltedPassword;
       self._sendProof(messageServer.authentication, randomNonce, saltedPassword);
-
-    })
+    } catch (error) {
+      self._abort();
+      reject(new Err.ReqlDriverError('Could not derive the key. Error:' + error.toString()));
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "url": "https://github.com/neumino/rethinkdbdash/issues"
   },
   "dependencies":{
-    "bluebird": ">= 3.0.1"
+    "bluebird": ">= 3.0.1",
+    "pbkdf2-sha256": ">= 1.1.1"
   },
   "devDependencies": {
     "mocha": ">= 1.20.0",


### PR DESCRIPTION
This PR probably needs more review, I basically just hacked this together to get my app running.

The gist is that rethinkdbdash (and the official rethinkdb driver) don't work with tls on node 0.10, this PR fixes that for rethinkdbdash.