### PR TITLE
Add getOptions to pool_master

### DIFF
--- a/lib/pool_master.js
+++ b/lib/pool_master.js
@@ -80,6 +80,10 @@ function PoolMaster(r, options) {
 }
 util.inherits(PoolMaster, events.EventEmitter);
 
+PoolMaster.prototype.getOptions = function() {
+  return this._options;
+}
+
 PoolMaster.prototype.getPools = function() {
   var result = [];
   helper.loopKeys(this._pools, function(pools, key) {
@@ -165,7 +169,7 @@ PoolMaster.prototype.handleAllServersResponse = function(servers) {
       var found = false;
       for(var j=0; j<self._pools[UNKNOWN_POOLS].length; j++) {
         if (found) break;
-        var pool = self._pools[UNKNOWN_POOLS][j]; 
+        var pool = self._pools[UNKNOWN_POOLS][j];
         // If a pool is created with localhost, it will probably match the first server even though it may not the the one
         // So it gets an id
         for(var k=0; k<server.network.canonical_addresses.length; k++) {
@@ -385,7 +389,7 @@ PoolMaster.prototype.fetchServers = function(useSeeds) {
     return null;
   }).error(function(error) {
     self._log('Could not retrieve the data from server_status: '+JSON.stringify(error));
-    
+
     var timeout;
     if (self._consecutiveFails === -1) {
       timeout = 0;


### PR DESCRIPTION
Hi @neumino,

This is a simple change for I can access the options here:
https://github.com/grantcarthew/node-rethinkdb-job-queue/blob/master/src/queue-db.js#L13-L16

The job queue supports passing a `rethinkdbdash` object, in which case the db, host, port etc is unknown.
It the moment I am reading the values using:

```js

q._host = q.r._poolMaster._options.host

```

With this pull request I can change it to something like:

```js

q._host = q.r.getPoolMaster().getOptions().host

```

Thanks mate.