### PR TITLE
Fix Buffer DeprecationWarning in Node 7

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -278,7 +278,7 @@ Connection.prototype._sendProof = function(authentication, randomNonce, saltedPa
   var message = JSON.stringify({
     authentication: clientFinalMessageWithoutProof + ",p=" + clientProof.toString("base64")
   })
-  this.connection.write(Buffer.concat([Buffer(message.toString()), NULL_BUFFER]))
+  this.connection.write(Buffer.concat([new Buffer(message.toString()), NULL_BUFFER]))
 }
 
 Connection.prototype._compareDigest = function(messageServer, resolve, reject) {


### PR DESCRIPTION
Just a basic fix for #304. Without this, Node >=7.0.0 prints the following warning to console:
```
(node:9443) DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
```