### PR TITLE
fix: return null where new Promises are created but not returned

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -295,11 +295,13 @@ Cursor.prototype._eachAsyncInternal = function(callback, finalResolve, finalReje
       if (self._stackSize <= MAX_CALL_STACK) {
         if (callback.length <= 1) {
           Promise.resolve(callback(row)).then(nextCb)
+          return null;
         }
         else {
           new Promise(function(resolve, reject) {
             return callback(row, resolve)
           }).then(nextCb);
+          return null;
         }
       }
       else {
@@ -313,9 +315,11 @@ Cursor.prototype._eachAsyncInternal = function(callback, finalResolve, finalReje
               new Promise(function(resolve, reject) {
                 return callback(row, resolve)
               }).then(resolve).catch(reject);
+              return null;
             }
           }, 0)
-        }).then(nextCb);;
+        }).then(nextCb);
+        return null;
       }
     }).error(function(error) {
       if ((error.message === 'No more rows in the '+self._type.toLowerCase()+'.') ||


### PR DESCRIPTION
Bluebird emits warnings when a promise is created in a function but
doesn't return it. Since the author wants these to be no-ops we have
to return null

This issue is also addressed by #288