### PR TITLE
Call `Error.captureStackTrace` after `this.message` is set

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -12,8 +12,8 @@ var frameTypes = protodef.Frame.FrameType;
 
 
 function ReqlDriverError(message, query, secondMessage) {
-  Error.captureStackTrace(this, ReqlDriverError);
   this.message = this.msg = message;
+  Error.captureStackTrace(this, ReqlDriverError);
 
   if ((Array.isArray(query) && (query.length > 0)) || (!Array.isArray(query) && query != null)) {
     if ((this.message.length > 0) && (this.message[this.message.length-1] === '.')) {
@@ -42,8 +42,8 @@ module.exports.ReqlDriverError = ReqlDriverError;
 
 
 function ReqlServerError(message, query) {
-  Error.captureStackTrace(this, ReqlServerError);
   this.message = this.msg = message;
+  Error.captureStackTrace(this, ReqlServerError);
 
   if ((Array.isArray(query) && (query.length > 0)) || (!Array.isArray(query) && query != null)) {
     if ((this.message.length > 0) && (this.message[this.message.length-1] === '.')) {
@@ -68,8 +68,8 @@ module.exports.ReqlServerError = ReqlServerError;
 
 
 function ReqlRuntimeError(message, query, frames) {
-  Error.captureStackTrace(this, ReqlRuntimeError);
   this.message = this.msg = message;
+  Error.captureStackTrace(this, ReqlRuntimeError);
 
   if ((query != null) && (frames)) {
     if ((this.message.length > 0) && (this.message[this.message.length-1] === '.')) {
@@ -133,8 +133,8 @@ module.exports.ReqlRuntimeError = ReqlRuntimeError;
 
 
 function ReqlCompileError(message, query, frames) {
-  Error.captureStackTrace(this, ReqlCompileError);
   this.message = message;
+  Error.captureStackTrace(this, ReqlCompileError);
 
   if ((query != null) && (frames)) {
     if ((this.message.length > 0) && (this.message[this.message.length-1] === '.')) {
@@ -174,8 +174,8 @@ module.exports.ReqlCompileError = ReqlCompileError;
 
 
 function ReqlClientError(message) {
-  Error.captureStackTrace(this, ReqlClientError);
   this.message = message;
+  Error.captureStackTrace(this, ReqlClientError);
 };
 ReqlClientError.prototype = new Error();
 ReqlClientError.prototype.name = 'ReqlClientError';


### PR DESCRIPTION
This change prevents `error.stack` from not including `error.message`.