### PR TITLE
Add return statements for promises to fix Bluebird errors.

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -96,7 +96,7 @@ Pool.prototype.getConnection = function() {
     }
 
     if (self._slowGrowth === false) {
-      self._expandBuffer();
+      return self._expandBuffer();
     }
 
   });
@@ -318,7 +318,7 @@ Pool.prototype._expandBuffer = function() {
   if ((this._draining === false) &&
       (this._pool.getLength() < this.options.buffer+this._localhostToDrain) &&
       (this._numConnections < this.options.max+this._localhostToDrain)) {
-    this.createConnection();
+    return this.createConnection();
   }
 }
 


### PR DESCRIPTION
I had a previous PR (#286) that fixed this, but you closed it off mentioning that it was already fixed, which it had not been.  I'm still running on my own fork and would like to switch back to canonical if at all possible.

Fixes: #285