### PR TITLE
Support `options.url` in the Connection constructor

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,3 +1,4 @@
+var url = require('url');
 var net = require('net');
 var tls = require('tls');
 var Promise = require('bluebird');
@@ -30,8 +31,7 @@ function Connection(r, options, resolve, reject) {
 
   // Set default options - We have to save them in case the user tries to reconnect
   if (!helper.isPlainObject(options)) options = {};
-  this.host = options.host || r._host;
-  this.port = options.port || r._port;
+
   if (options.authKey != null) {
     if (options.user != null || options.password != null) {
       throw new Err.ReqlDriverError('Cannot use both authKey and password');
@@ -67,40 +67,12 @@ function Connection(r, options, resolve, reject) {
   this.open = false; // true only if the user can write on the socket
   this.timeout = null;
 
-  if (options.connection) {
-    this.connection = options.connection;
-  }
-  else {
-    var family = 'IPv4';
-    if (net.isIPv6(self.host)) {
-      family = 'IPv6';
-    }
-
-    var connectionArgs = {
-      host: self.host,
-      port: self.port,
-      family: family
-    }
-
-    var tlsOptions = options.ssl || false;
-    if (tlsOptions === false) {
-      self.connection = net.connect(connectionArgs);
-    } else {
-      if (helper.isPlainObject(tlsOptions)) {
-        // Copy the TLS options in connectionArgs
-        helper.loopKeys(tlsOptions, function(tlsOptions, key) {
-          connectionArgs[key] = tlsOptions[key];
-        });
-      }
-      self.connection = tls.connect(connectionArgs);
-    }
-  }
-
-  self.connection.setKeepAlive(true);
+  this.connection = this._connect(options, r);
+  this.connection.setKeepAlive(true);
 
   self.timeoutOpen = setTimeout(function() {
     self.connection.end(); // Send a FIN packet
-    reject(new Err.ReqlDriverError('Failed to connect to '+self.host+':'+self.port+' in less than '+self.timeoutConnect+'s').setOperational());
+    reject(new Err.ReqlDriverError('Failed to connect to '+self.getAddress()+' in less than '+self.timeoutConnect+'s').setOperational());
   }, self.timeoutConnect*1000);
 
   self.connection.on('end', function() {
@@ -121,7 +93,7 @@ function Connection(r, options, resolve, reject) {
   });
   self.connection.setNoDelay();
   self.connection.once('error', function(error) {
-    reject(new Err.ReqlDriverError('Failed to connect to '+self.host+':'+self.port+'\nFull error:\n'+JSON.stringify(error)).setOperational());
+    reject(new Err.ReqlDriverError('Failed to connect to '+self.getAddress()+'\nFull error:\n'+JSON.stringify(error)).setOperational());
   });
   self.connection.on('connect', function() {
     self.connection.removeAllListeners('error');
@@ -145,7 +117,7 @@ function Connection(r, options, resolve, reject) {
       // The TCP connection is open, but the ReQL connection wasn't established.
       // We can just abort the whole thing
       self.open = false;
-      reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.host+':'+self.port).setOperational());
+      reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.getAddress()).setOperational());
     });
   });
   self.connection.once('end', function() {
@@ -216,6 +188,49 @@ function Connection(r, options, resolve, reject) {
 
 util.inherits(Connection, events.EventEmitter);
 
+Connection.prototype._connect = function(options, r) {
+  var address;
+  this.getAddress = function() {
+    return address;
+  };
+
+  if (options.connection) {
+    if (options.connection.localAddress) {
+      address = options.connection.localAddress + ':' + options.connection.localPort;
+    } else {
+      address = options.connection.remoteAddress + ':' + options.connection.remotePort;
+    }
+    return options.connection;
+  }
+
+  var args = {};
+  var protocol;
+  if (options.url) {
+    var urlObj = url.parse(options.url);
+    protocol = urlObj.protocol;
+    args.host = urlObj.hostname;
+    args.port = urlObj.port || r._port;
+    args.path = urlObj.path;
+  } else {
+    protocol = options.ssl ? 'https:' : 'http:';
+    args.host = options.host || r._host;
+    args.port = options.port || r._port;
+  }
+  args.family = net.isIPv6(args.host) ? 'IPv6' : 'IPv4';
+  address = protocol + '//' + args.host + ':' + args.port + (args.path || '');
+
+  var tlsOptions = options.ssl || false;
+  if (!tlsOptions) {
+    return net.connect(args);
+  }
+  if (helper.isPlainObject(tlsOptions)) {
+    helper.loopKeys(tlsOptions, function(tlsOptions, key) {
+      args[key] = tlsOptions[key];
+    });
+  }
+  return tls.connect(args);
+}
+
 Connection.prototype._checkProtocolVersion = function(messageServer, reject) {
   // Expect max_protocol_version, min_protocol_version, server_version, success
   var minVersion = messageServer.min_protocol_version
@@ -250,7 +265,7 @@ Connection.prototype._computeSaltedPassword = function(messageServer, reject) {
       // The TCP connection is open, but the ReQL connection wasn't established.
       // We can just abort the whole thing
       self.open = false;
-      reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.host+':'+self.port).setOperational());
+      reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.getAddress()).setOperational());
     });
   } else {
     crypto.pbkdf2(self.password, salt, iterations, KEY_LENGTH, "sha256", function(error, saltedPassword) {
@@ -265,7 +280,7 @@ Connection.prototype._computeSaltedPassword = function(messageServer, reject) {
         // The TCP connection is open, but the ReQL connection wasn't established.
         // We can just abort the whole thing
         self.open = false;
-        reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.host+':'+self.port).setOperational());
+        reject(new Err.ReqlDriverError('Failed to perform handshake with '+self.getAddress()).setOperational());
       });
     })
   }
@@ -442,7 +457,7 @@ Connection.prototype._processResponse = function(response, token) {
       if (self.metadata[token].options.profile === true) {
         self.metadata[token].resolve({
           profile: response.p,
-          result: stream 
+          result: stream
         });
       }
       else {
@@ -535,7 +550,7 @@ Connection.prototype._processResponse = function(response, token) {
         if (self.metadata[token].options.profile === true) {
           currentResolve({
             profile: response.p,
-            result: stream 
+            result: stream
           });
         }
         else {
@@ -624,7 +639,7 @@ Connection.prototype._processResponse = function(response, token) {
         }
 
         // We need to keep the options in the else statement,
-        // so we clean it inside the if/else blocks (the one looking 
+        // so we clean it inside the if/else blocks (the one looking
         // if a cursor was already created)
         if (typeof self.metadata[token].endResolve !== 'function') {
           // We do not want to delete the metadata if there is an END query waiting

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -20,6 +20,7 @@ function Pool(r, options) {
   this.options.silent = options.silent || false;
 
   this.options.connection = {
+    url: options.url,
     host: options.host || this._r._host,
     port: options.port || this._r._port,
     db: options.db || this._r._db,
@@ -399,8 +400,9 @@ Pool.prototype.drain = function() {
   return p;
 }
 
-
 Pool.prototype.getAddress = function() {
-  return this.options.connection.host+':'+this.options.connection.port;
+  var options = this.options.connection;
+  return options.url || (options.host + ':' + options.port);
 }
+
 module.exports = Pool;


### PR DESCRIPTION
This allows for connecting to urls like `rethinkdb://host:port/path`

The port is optional, defaulting to `28015`.