### PR TITLE
Remove unused properties from `pool.options.connection`

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -27,8 +27,6 @@ function Pool(r, options) {
     authKey: options.authKey,
     user: options.user,
     password: options.password,
-    cursor: options.cursor || false,
-    stream: options.stream || false,
     ssl: options.ssl || false,
     pingInterval: options.pingInterval || this._r._pingInterval
   }


### PR DESCRIPTION
The `stream` and `cursor` options for `r.connect` are not used anymore, as far as I can tell.