### PR TITLE
Fix pool matching when a server has no assigned pool

### DIFF
--- a/lib/pool_master.js
+++ b/lib/pool_master.js
@@ -353,30 +353,33 @@ PoolMaster.prototype.fetchServers = function(useSeeds) {
         else {
           var found = false;
           for(var i=0; i<self._pools[UNKNOWN_POOLS].length; i++) {
-            if (((server.network.canonical_addresses[k].host === self._pools[UNKNOWN_POOLS][i].options.connection.host) ||
-              (helper.localhostAliases.hasOwnProperty(server.network.canonical_addresses[k].host) && (helper.localhostAliases.hasOwnProperty(self._pools[UNKNOWN_POOLS][i].options.connection.host)))) &&
-              (server.network.reql_port === self._pools[UNKNOWN_POOLS][i].options.connection.port)) {
-              found = true;
-
-              (function (pool) {
-                self._log('Removing pool connected to: '+pool.getAddress())
-                var pool = self._pools[UNKNOWN_POOLS].splice(i, 1)[0];
-                pool.drain().then(function() {
-                  pool.removeAllListeners();
-                }).error(function(error) {
-                  if (self._options.silent !== true) {
-                    self._log('Pool connected to: '+pool.getAddress()+' could not be properly drained.')
-                    self._log(error.message);
-                    self._log(error.stack);
-                  }
-                });
-              })(self._pools[UNKNOWN_POOLS][i]);
+            var pool = self._pools[UNKNOWN_POOLS][i];
+            for(var k=0; k<server.network.canonical_addresses.length; k++) {
+              if (((server.network.canonical_addresses[k].host === pool.options.connection.host) ||
+                (helper.localhostAliases.hasOwnProperty(server.network.canonical_addresses[k].host) && (helper.localhostAliases.hasOwnProperty(pool.options.connection.host)))) &&
+                (server.network.reql_port === pool.options.connection.port)) {
+                found = true;
+                break;
+              }
+            }
+            if (found) {
+              self._log('Removing pool connected to: '+pool.getAddress())
+              self._pools[UNKNOWN_POOLS].splice(i, 1);
+              pool.drain().then(function() {
+                pool.removeAllListeners();
+              }).fail(function(error) {
+                if (self._options.silent !== true) {
+                  self._log('Pool connected to: '+pool.getAddress()+' could not be properly drained.')
+                  self._log(error.message);
+                  self._log(error.stack);
+                }
+              });
               break;
             }
           }
-        }
-        if (found === false) {
-          self._log('A server was removed but no pool for this server exists...')
+          if (!found) {
+            self._log('A server was removed but no pool for this server exists...')
+          }
         }
       }
       // We ignore this change since this it doesn't affect whether the server


### PR DESCRIPTION
There was a missing for-loop that caused a `ReferenceError` to be thrown.