### PR TITLE
Delay the creation of each pool

### DIFF
--- a/lib/pool_master.js
+++ b/lib/pool_master.js
@@ -43,43 +43,46 @@ function PoolMaster(r, options) {
   //self._usingPool = true; // If we have used the pool
   self._seed = 0;
 
-  var pool;
-  if (Array.isArray(options.servers)) {
-    if (options.servers.length > 0) {
-      self._servers = options.servers;
-      for(var i=0; i<options.servers.length; i++) {
-        var settings = self.createPoolSettings(options, options.servers[i], self._log);
-        pool = new Pool(self._r, settings);
-        self._pools[UNKNOWN_POOLS].push(pool);
-        // A pool is considered healthy by default such that people can do
-        // var = require(...)(); query.run();
-        self._healthyPools.push(pool);
-        self.emitStatus()
+  // Delay the creation of each pool, to allow for event listeners to be attached.
+  setImmediate(function() {
+    var pool;
+    if (Array.isArray(options.servers)) {
+      if (options.servers.length > 0) {
+        self._servers = options.servers;
+        for(var i=0; i<options.servers.length; i++) {
+          var settings = self.createPoolSettings(options, options.servers[i], self._log);
+          pool = new Pool(self._r, settings);
+          self._pools[UNKNOWN_POOLS].push(pool);
+          // A pool is considered healthy by default such that people can do
+          // var = require(...)(); query.run();
+          self._healthyPools.push(pool);
+          self.emitStatus()
+        }
+      }
+      else {
+        throw new Err.ReqlDriverError("If `servers` is an array, it must contain at least one server")
       }
     }
     else {
-      throw new Err.ReqlDriverError("If `servers` is an array, it must contain at least one server")
+      self._servers = [{
+        host: options.host || 'localhost',
+        port: options.port || 28015
+      }]
+      var settings = self.createPoolSettings(options, {}, self._log);
+      pool = new Pool(self._r, settings);
+      self._pools[UNKNOWN_POOLS].push(pool);
+      self._healthyPools.push(pool);
+      self.emitStatus()
     }
-  }
-  else {
-    self._servers = [{
-      host: options.host || 'localhost',
-      port: options.port || 28015
-    }]
-    var settings = self.createPoolSettings(options, {}, self._log);
-    pool = new Pool(self._r, settings);
-    self._pools[UNKNOWN_POOLS].push(pool);
-    self._healthyPools.push(pool);
-    self.emitStatus()
-  }
 
-  // Initialize all the pools - bind listeners
-  for(var i=0; i<self._pools[UNKNOWN_POOLS].length; i++) {
-    self.initPool(self._pools[UNKNOWN_POOLS][i]);
-  }
-  if ((self._discovery === true)) {
-    self._timeout = setTimeout(function() { self.fetchServers() }, 0);
-  }
+    // Initialize all the pools - bind listeners
+    for(var i=0; i<self._pools[UNKNOWN_POOLS].length; i++) {
+      self.initPool(self._pools[UNKNOWN_POOLS][i]);
+    }
+    if ((self._discovery === true)) {
+      self._timeout = setTimeout(function() { self.fetchServers() }, 0);
+    }
+  });
 }
 util.inherits(PoolMaster, events.EventEmitter);
 


### PR DESCRIPTION
This will allow event listeners to be attached without missing any events.

The only change is wrapping the pool initialization in a `setImmediate` call.

This fixes #334.