### PR TITLE
Add async iterator interface to cursors

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -2,6 +2,7 @@ var Promise = require('bluebird');
 var Err = require(__dirname+'/error.js');
 var helper = require(__dirname+'/helper.js');
 var EventEmitter = require('events').EventEmitter;
+var $$asyncIterator = require('iterall').$$asyncIterator;
 
 var MAX_CALL_STACK = 1000;
 
@@ -365,6 +366,37 @@ Cursor.prototype._eachCb = function(err, data) {
     }
   }
 }
+
+Cursor.prototype.asyncIterator = function() {
+  var self = this;
+  return {
+    next: function() {
+      var iter = this;
+      return self._next().then(value => {
+        return {
+          done: false,
+          value: value
+        };
+      }).error(function(error) {
+        if ((error.message !== 'You cannot retrieve data from a cursor that is closed.') &&
+            (error.message.match(/You cannot call `next` on a closed/) === null)) {
+          return iter.throw(error);
+        } else {
+          return iter.return();
+        }
+      });
+    },
+    return: function() {
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw: function(err) {
+      return Promise.reject(err);
+    },
+    [$$asyncIterator]: function() {
+      return this;
+    }
+
+}}
 
 var methods = [
   'addListener',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "url": "https://github.com/neumino/rethinkdbdash/issues"
   },
   "dependencies": {
-    "bluebird": ">= 3.0.1"
+    "bluebird": ">= 3.0.1",
+    "iterall": "^1.2.2"
   },
   "devDependencies": {
     "mocha": ">= 1.20.0",


### PR DESCRIPTION
See #370, this patch adds a `cursor.asyncIterator` method which returns an async iterator:

```JS
const feed = yield r.db().table().changes().run();

const iterator = feed.asyncIterator();

for await (var change of iterator) {
  console.log(change);
}
console.log('Done!');
```

I added `iterall` as a dependency since I need to use it in the tests anyway, but if you want me to I can move it to the `devDependencies` and inline the `$$asyncIterator` polyfill snippet. (it's like 3 lines)