### PR TITLE
Change localhost to 127.0.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function r() {
   _r._Term = Term;
   return _r;
 };
-r.prototype._host = 'localhost';
+r.prototype._host = '127.0.0.1';
 r.prototype._port = 28015;
 r.prototype._authKey = '';
 r.prototype._user = 'admin';


### PR DESCRIPTION
Localhost fails in some versions of windows or when is not connected to any network or when host file is bad completed, 127.0.0.1 works every time.