### PR TITLE
add missing `run` options

### DIFF
--- a/lib/term.js
+++ b/lib/term.js
@@ -80,7 +80,8 @@ Term.prototype.run = function(connection, options, callback) {
       var keepGoing = true; // we need it just to avoir calling resolve/reject multiple times
       helper.loopKeys(options, function(options, key) {
         if (keepGoing === true) {
-          if ((key === 'readMode') || (key === 'durability') || (key === 'db') ||
+          if ((key === 'returnChanges') || (key === 'conflict') ||
+            (key === 'readMode') || (key === 'durability') || (key === 'db') ||
             (key === 'noreply') || (key === 'arrayLimit') || (key === 'profile') ||
             (key === 'minBatchRows') || (key === 'maxBatchRows') || (key === 'maxBatchBytes') ||
             (key === 'maxBatchSeconds') || (key === 'firstBatchScaledownFactor')) {
@@ -159,7 +160,8 @@ Term.prototype.run = function(connection, options, callback) {
           var keepGoing = true;
           helper.loopKeys(options, function(options, key) {
             if (keepGoing === true) {
-              if ((key === 'readMode') || (key === 'durability') || (key === 'db') ||
+              if ((key === 'returnChanges') || (key === 'conflict') ||
+                  (key === 'readMode') || (key === 'durability') || (key === 'db') ||
                   (key === 'noreply') || (key === 'arrayLimit') || (key === 'profile') ||
                   (key === 'minBatchRows') || (key === 'maxBatchRows') || (key === 'maxBatchBytes') ||
                   (key === 'maxBatchSeconds') || (key === 'firstBatchScaledownFactor')) {


### PR DESCRIPTION
I noticed that `run` was missing `options` when I replaced the official `rethinkdb` driver with `rethinkdbdash`. There are probably more options, but I added the options I saw were throwing errors in my application.

Thanks!